### PR TITLE
chore: use qubit safety terminology on landing page

### DIFF
--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -17,7 +17,7 @@ const featureConfig = [
       'The guppylang compiler uses a powerful but unobtrusive type system to provide helpful error messages.',
   },
   {
-    title: 'Linear Qubits',
+    title: 'Qubit Safety',
     description:
       'Qubits have a linear type, following an intuitive ownership model that prevents no-cloning errors and memory leaks.',
   },


### PR DESCRIPTION
To avoid confusion with qubits being on a line. E.g. Cirq's `LineQubit`.

What is meant is that qubits are a linear type in Guppy.