### PR TITLE
chore: Update CQCL organization name to quantinuum

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     add-to-project:
-        uses: CQCL/hugrverse-actions/.github/workflows/add-to-project.yml@main
+        uses: quantinuum/hugrverse-actions/.github/workflows/add-to-project.yml@main
         with:
             project-url: https://github.com/orgs/quantinuum-dev/projects/10
         secrets:

--- a/.github/workflows/drop-cache.yml
+++ b/.github/workflows/drop-cache.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
     drop-cache:
-        uses: CQCL/hugrverse-actions/.github/workflows/drop-cache.yml@main
+        uses: quantinuum/hugrverse-actions/.github/workflows/drop-cache.yml@main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,6 @@ on:
 jobs:
     check-title:
         name: check-title
-        uses: CQCL/hugrverse-actions/.github/workflows/pr-title.yml@main
+        uses: quantinuum/hugrverse-actions/.github/workflows/pr-title.yml@main
         secrets:
             GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "sphinx/guppylang"]
 	path = sphinx/guppylang
-	url = https://github.com/CQCL/guppylang.git
+	url = https://github.com/quantinuum/guppylang.git
 	branch = main

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This repository contains documentation for the Guppy programming language.
 * The Guppy landing page
 * The API documentation for the guppylang package
 * FAQs, changelog and migration guides
-* The guppylang [example notebooks](https://github.com/CQCL/guppylang/tree/main/examples) (included via the guppylang submodule)
+* The guppylang [example notebooks](https://github.com/quantinuum/guppylang/tree/main/examples) (included via the guppylang submodule)
 
-The Sphinx docs are written in MyST markdown and rendered with the [myst-nb](https://myst-nb.readthedocs.io/en/latest/) library. This variant of markdown supports code cells which are executed at docs build time. See the section on [text-based notebooks](https://myst-nb.readthedocs.io/en/latest/authoring/basics.html#text-based-notebooks). The docs are styled with the [quantinuum-sphinx](https://github.com/CQCL/quantinuum-sphinx) theme.
+The Sphinx docs are written in MyST markdown and rendered with the [myst-nb](https://myst-nb.readthedocs.io/en/latest/) library. This variant of markdown supports code cells which are executed at docs build time. See the section on [text-based notebooks](https://myst-nb.readthedocs.io/en/latest/authoring/basics.html#text-based-notebooks). The docs are styled with the [quantinuum-sphinx](https://github.com/quantinuum/quantinuum-sphinx) theme.
 
-For information on how the landing page is built, see the [landing page README](https://github.com/CQCL/guppy-docs/blob/main/landing/README.md).
+For information on how the landing page is built, see the [landing page README](https://github.com/quantinuum/guppy-docs/blob/main/landing/README.md).
 
 ## Updating the docs for a new Guppy release
 
@@ -38,10 +38,10 @@ Requirements:
 
 See the `devenv.nix` file.
 
-First clone the repository making sure to checkout the [guppylang](https://github.com/CQCL/guppylang) submodule.
+First clone the repository making sure to checkout the [guppylang](https://github.com/quantinuum/guppylang) submodule.
 
 ```shell
-git clone git@github.com:CQCL/guppy-docs.git --recurse-submodules
+git clone git@github.com:quantinuum/guppy-docs.git --recurse-submodules
 ```
 
 Alternatively you can update the submodules if you have already cloned the repository.

--- a/landing/src/app/layout.tsx
+++ b/landing/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css'
-import '@cqcl/quantinuum-ui/tokens.css'
+import '@quantinuum/quantinuum-ui/tokens.css'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import { Inter, JetBrains_Mono } from 'next/font/google'

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { CodeSnippet } from './code_snippet'
-import { DocsFooter, DocsNavBar } from '@cqcl/quantinuum-ui'
+import { DocsFooter, DocsNavBar } from '@quantinuum/quantinuum-ui'
 import { Button, Separator } from '@quantinuum/quantinuum-ui'
 import { ArrowRight } from 'lucide-react'
 import Image from 'next/image'
@@ -285,8 +285,8 @@ export default async function Home() {
           </div>
           <div className="flex flex-col gap-4">
             {[
-              { title: 'guppylang', href: 'https://github.com/CQCL/guppylang' },
-              { title: 'hugr', href: 'https://github.com/CQCL/hugr' },
+              { title: 'guppylang', href: 'https://github.com/quantinuum/guppylang' },
+              { title: 'hugr', href: 'https://github.com/quantinuum/hugr' },
             ].map((item) => {
               return (
                 <Link

--- a/landing/tailwind.config.ts
+++ b/landing/tailwind.config.ts
@@ -1,5 +1,5 @@
 //@ts-ignore
-import { tailwindTheme } from '@cqcl/quantinuum-ui'
+import { tailwindTheme } from '@quantinuum/quantinuum-ui'
 import path from 'path'
 import { Config } from 'tailwindcss'
 import plugin from 'tailwindcss/plugin'
@@ -23,7 +23,7 @@ export default {
   content: [
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     path.join(
-      path.dirname(require.resolve('@cqcl/quantinuum-ui')),
+      path.dirname(require.resolve('@quantinuum/quantinuum-ui')),
       '**/*.{js,ts,jsx,tsx,mdx}'
     ),
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
 prerelease = "allow"
 
 [tool.uv.sources]
-# guppylang = { git = "https://github.com/CQCL/guppylang/", rev = "8efeb3c", subdirectory = "guppylang" }
-# hugr = { git = "https://github.com/cqcl/hugr.git", rev = "fe98ba1", subdirectory = "hugr-py" }
-# tket2 = { git = "https://github.com/CQCL/tket2", subdirectory = "tket2-py", rev = "309879e" }
+# guppylang = { git = "https://github.com/quantinuum/guppylang/", rev = "8efeb3c", subdirectory = "guppylang" }
+# hugr = { git = "https://github.com/quantinuum/hugr.git", rev = "fe98ba1", subdirectory = "hugr-py" }
+# tket2 = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket2-py", rev = "309879e" }
 
 [dependency-groups]
 dev = [{ include-group = "docs" }]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -42,7 +42,7 @@ autosectionlabel_prefix_document = True
 # Sphinx autosummary
 # https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
 
-# See https://github.com/CQCL/guppylang/pull/1028
+# See https://github.com/quantinuum/guppylang/pull/1028
 autosummary_ignore_module_all = False  # Respect __all__ if specified
 
 
@@ -81,7 +81,7 @@ nb_execution_mode = "cache"
 nb_execution_show_tb = True  # Show traceback if cell execution fails
 nb_execution_raise_on_error = True  # Cell execution failures are errors not warnings
 nb_execution_timeout = 90  # Cells which take >90s give timeout error.
-nb_merge_streams = True # Accumulates all stdout streams into one, same with stderr
+nb_merge_streams = True  # Accumulates all stdout streams into one, same with stderr
 # ----------------------
 
 
@@ -131,7 +131,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "nexus": ("https://docs.quantinuum.com/nexus/", None),
     "pytket": ("https://docs.quantinuum.com/tket/api-docs/", None),
-    "hugr": ("https://cqcl.github.io/hugr/", None),
+    "hugr": ("https://quantinuum.github.io/hugr/", None),
 }
 
 intersphinx_disabled_reftypes = ["*"]

--- a/sphinx/faqs.md
+++ b/sphinx/faqs.md
@@ -54,4 +54,4 @@ This Guppy function doesn't currently have compilation to HUGR. Please find/rais
 
 ## Why am I getting "no lowering found" errors?
 
-Though Guppy can compile your operation to HUGR, the lowering to LLVM executable code for the Selene simulator doesn't yet work. Please find a workaround or raise an issue on the [HUGR repository](https://github.com/cqcl/hugr/).
+Though Guppy can compile your operation to HUGR, the lowering to LLVM executable code for the Selene simulator doesn't yet work. Please find a workaround or raise an issue on the [HUGR repository](https://github.com/quantinuum/hugr/).

--- a/sphinx/getting_started.md
+++ b/sphinx/getting_started.md
@@ -18,9 +18,9 @@ pip install guppylang
 
 Guppy can be used with Python versions 3.10, 3.11, 3.12 and 3.13. The MacOS, Linux and Windows operating systems are supported.
 
-The source code for Guppy can be found in a public repository on [github](https://github.com/CQCL/guppylang). If you have a feature request or think you have found a bug, feel free to raise a [github issue](https://github.com/CQCL/guppylang/issues).
+The source code for Guppy can be found in a public repository on [github](https://github.com/quantinuum/guppylang). If you have a feature request or think you have found a bug, feel free to raise a [github issue](https://github.com/quantinuum/guppylang/issues).
 
-Guppy programs can be executed on the [Selene](https://github.com/CQCL/selene) emulator. As of the v0.21 release, Selene is now included with `guppylang` and powers the [guppylang.emulator](../sphinx/api/emulator.md) module under the hood.
+Guppy programs can be executed on the [Selene](https://github.com/quantinuum/selene) emulator. As of the v0.21 release, Selene is now included with `guppylang` and powers the [guppylang.emulator](../sphinx/api/emulator.md) module under the hood.
 
 ## Example: Quantum Teleportation
 

--- a/sphinx/index.md
+++ b/sphinx/index.md
@@ -8,5 +8,5 @@ api/api_index.md
 guppylang/guppylang/CHANGELOG.md
 migration_guide.md
 faqs.md
-Github <https://github.com/CQCL/guppylang>
+Github <https://github.com/quantinuum/guppylang>
 ```

--- a/sphinx/language_guide/static.md
+++ b/sphinx/language_guide/static.md
@@ -11,7 +11,7 @@ kernelspec:
 
 While Guppy functions mostly look like regular Python functions (just annotated with the `@guppy` decorator), the code they contain is processed differently compared to Python code. You can normally run Python programs directly on your machine, whereas we want to be able to run Guppy programs with a variety of simulators and quantum hardware. 
 
-In order to achieve this, programs are statically compiled into an intermediate representation called [HUGR](https://github.com/CQCL/hugr?tab=readme-ov-file).  An intermediate representation allows us to optimise programs before further converting them to code that can actually be executed on the desired target. 
+In order to achieve this, programs are statically compiled into an intermediate representation called [HUGR](https://github.com/quantinuum/hugr?tab=readme-ov-file).  An intermediate representation allows us to optimise programs before further converting them to code that can actually be executed on the desired target. 
 
 A big advantage of compilation is that it helps us catch errors earlier than runtime. For example, the compiler ensures that variables are definitely defined before they are used.
 

--- a/sphinx/migration_guide.md
+++ b/sphinx/migration_guide.md
@@ -67,9 +67,9 @@ to be successful. However, such opaque operations cannot be emulated or submitte
 
 In the code snippet below we will construct a circuit for performing a two-qubit unitary operation which we will specify as a numpy array. This unitary box is not natively supported.
 
-[qsys-ext]: https://github.com/CQCL/tket2/blob/b0103930a4b47ecc457e8a0e023e131955c553bd/tket-qsystem/src/extension/qsystem.rs
+[qsys-ext]: https://github.com/quantinuum/tket2/blob/b0103930a4b47ecc457e8a0e023e131955c553bd/tket-qsystem/src/extension/qsystem.rs
 
-[quan-ext]: https://github.com/CQCL/tket2/blob/b0103930a4b47ecc457e8a0e023e131955c553bd/tket/src/ops.rs
+[quan-ext]: https://github.com/quantinuum/tket2/blob/b0103930a4b47ecc457e8a0e023e131955c553bd/tket/src/ops.rs
 
 [qsys-std]: api/generated/guppylang.std.qsystem.rst
 [quan-std]: api/generated/guppylang.std.quantum.rst
@@ -149,10 +149,10 @@ If you want to optimize your quantum program using pytket, you can create a pytk
 
 ## Execution of quantum programs
 
-The Guppy language comes with a built in [emulator](api/emulator.md) module built on top of [Selene](https://github.com/CQCL/selene) for the execution of quantum programs. This emulator can execute compiled Guppy programs which include control flow and constructs from the standard library. There are two simulation modes available namely stabilizer and statevector which are provided via the Stim and QuEST backends respectively. Selene also supports [statevector output](guppylang/examples/state_results.ipynb) for testing and debugging. 
+The Guppy language comes with a built in [emulator](api/emulator.md) module built on top of [Selene](https://github.com/quantinuum/selene) for the execution of quantum programs. This emulator can execute compiled Guppy programs which include control flow and constructs from the standard library. There are two simulation modes available namely stabilizer and statevector which are provided via the Stim and QuEST backends respectively. Selene also supports [statevector output](guppylang/examples/state_results.ipynb) for testing and debugging. 
 
 For more information on the Selene emulator see the [Selene documentation](https://docs.quantinuum.com/selene).
 
 ## Footnotes 
 
-[^1]: Guppy programs are compiled to [HUGR](https://github.com/cqcl/hugr) which is a new intermediate representation of quantum programs.
+[^1]: Guppy programs are compiled to [HUGR](https://github.com/quantinuum/hugr) which is a new intermediate representation of quantum programs.


### PR DESCRIPTION
The renamed `quantinuum-ui` package is already in the [npm registry](https://www.npmjs.com/package/@quantinuum/quantinuum-ui), so I updated it here too.