### PR TITLE
docs: Update main decorator docs

### DIFF
--- a/sphinx/api/decorator.md
+++ b/sphinx/api/decorator.md
@@ -4,9 +4,23 @@
 ```{eval-rst}
 .. currentmodule:: guppylang.decorator
 
-.. decorator:: guppy
+.. decorator:: guppy (*, unitary=False, control=False, dagger=False, power=False, max_qubits=None)
 
-   Registers a function for Guppy compilation.
+   Registers a function for Guppy compilation. This is the main decorator that applies to most use cases / functions
+   written in Guppy. 
+   
+   :keyword unitary: Convienience argument that when set to `True`, sets `control=True`, `dagger=True`, and `power=True`.
+   :type unitary: python:bool
+   :keyword control: Marks a function as being controllable, similar to how a `NOT` gate is controllable to form a `CNOT`, etc.
+   :type control: python:bool
+   :keyword dagger: Marks a function as having an auto-inferrable adjoint.
+   :type dagger: python:bool
+   :keyword power: Marks a function as having an auto-inferrable power operation, that applies the function repeteadly.
+   :type power: python:bool
+   :keyword max_qubits: Hints the maximum number of qubits that this function uses. When used on the entrypoint function,
+     allows to omit the `n_qubits` parameter when calling :func:`~guppylang.defs.GuppyFunctionDefinition.emulator`.
+   :type max_qubits: python:int | None
+   :rtype: GuppyFunctionDefinition
 
    .. code-block:: python
 

--- a/sphinx/api/decorator.md
+++ b/sphinx/api/decorator.md
@@ -9,13 +9,13 @@
    Registers a function for Guppy compilation. This is the main decorator that applies to most use cases / functions
    written in Guppy. 
    
-   :keyword unitary: Convienience argument that when set to `True`, sets `control=True`, `dagger=True`, and `power=True`.
+   :keyword unitary: Convenience argument that when set to `True`, sets `control=True`, `dagger=True`, and `power=True`.
    :type unitary: python:bool
    :keyword control: Marks a function as being controllable, similar to how a `NOT` gate is controllable to form a `CNOT`, etc.
    :type control: python:bool
-   :keyword dagger: Marks a function as having an auto-inferrable adjoint.
+   :keyword dagger: Marks a function as having an auto-inferable adjoint.
    :type dagger: python:bool
-   :keyword power: Marks a function as having an auto-inferrable power operation, that applies the function repeteadly.
+   :keyword power: Marks a function as having an auto-inferable power operation, that applies the function repeatedly.
    :type power: python:bool
    :keyword max_qubits: Hints the maximum number of qubits that this function uses. When used on the entrypoint function,
      allows to omit the `n_qubits` parameter when calling :func:`~guppylang.defs.GuppyFunctionDefinition.emulator`.


### PR DESCRIPTION
Updates the main `@guppy` decorator docs to include the keyword arguments one can specify as of right now.
<img width="1586" height="956" alt="image" src="https://github.com/user-attachments/assets/02335d41-d1f8-41a1-8ff9-526253beabde" />

I am quite unsure as to the specifics of the modifiers though, for now I took the description from `tket` and adapted the wording: https://github.com/Quantinuum/tket2/blob/2d3fe8e5b587f2e0b5d1475adb05308b64cc2564/tket/src/extension/modifier.rs#L116-L126

Closes #41