### PR TITLE
fix: update incorrect information in structs page, add a test

### DIFF
--- a/sphinx/language_guide/data_types/structs.md
+++ b/sphinx/language_guide/data_types/structs.md
@@ -123,7 +123,9 @@ class PauliString:
 
     @guppy
     def commutes_with(self: "PauliString", other: "PauliString") -> bool:
-        return not bitwise_and_parity(self.xs, other.zs) ^ bitwise_and_parity(self.zs, other.xs)
+        return not bitwise_and_parity(self.xs, other.zs) ^ bitwise_and_parity(
+            self.zs, other.xs
+        )
 
 PauliString.check()
 ```
@@ -137,6 +139,7 @@ from typing import Generic
 
 n = guppy.nat_var("n")
 
+
 @guppy.struct
 class PauliString(Generic[n]):
     xs: array[bool, n]
@@ -148,7 +151,9 @@ class PauliString(Generic[n]):
 
     @guppy
     def commutes_with(self: "PauliString[n]", other: "PauliString[n]") -> bool:
-        return not bitwise_and_parity(self.xs, other.zs) ^ bitwise_and_parity(self.zs, other.xs)
+        return not bitwise_and_parity(self.xs, other.zs) ^ bitwise_and_parity(
+            self.zs, other.xs
+        )
 
 PauliString.check()
 ```


### PR DESCRIPTION
There were a number of issues in this page. Deployed version -> https://docs.quantinuum.com/guppy/language_guide/data_types/structs.html

1. Firstly the commutation check was wrong (see #58 ) There was a change to this in #19 that I should have checked properly.
2. The commutation check was also inconsistent on different parts of the page.
3. The methods did not have the correct generic type annotation. for `__eq__` and `commutes_with` should take inputs of type `"PauliString[n]"` rather than `"PauliString"`. This passed the typecheck but gave an error if we tried to use the `__eq__` method for a `PauliString instance.
4. I've also added an example which tests the commutation and equality checks. I think this is nice to show.


closes #58 