### PR TITLE
fix: exclude some unhelpful dunder methods from the API docs

### DIFF
--- a/sphinx/_templates/autosummary/class.rst
+++ b/sphinx/_templates/autosummary/class.rst
@@ -9,7 +9,7 @@
 .. autoclass:: {{ objname }}
    :members:
    :undoc-members:
-   :exclude-members: __module__, __weakref__, __dict__, __annotations__, __dataclass_params__, __dataclass_fields__, __match_args__, __orig_bases__, __parameters__ 
+   :exclude-members: __module__, __weakref__, __dict__, __annotations__, __dataclass_params__, __dataclass_fields__, __match_args__, __orig_bases__, __parameters__, __abstractmethods__, __firstlineno__, __static_attributes__, __hash__, __annotate_func__, __annotations_cache__, __protocol_attrs__, __subclasshook__
    :special-members:
 
    {% block methods %}

--- a/sphinx/api/defs.md
+++ b/sphinx/api/defs.md
@@ -25,5 +25,10 @@
     .. automethod:: __eq__
     .. automethod:: __getattr__
 
+.. autoclass:: GuppyEnumDefinition
+    :show-inheritance:
+
+    .. automethod:: __getattr__
+
 .. autoexception:: EntrypointArgsError
 ```


### PR DESCRIPTION
Expand the list of excluded members in the sphinx autosummary template. This reduces the noise caused by unhelpful dunder methods in the API docs.

Driveby: document `GuppyEnumDefinition`