### PR TITLE
docs: Add link name to decorator api

### DIFF
--- a/sphinx/api/decorator.md
+++ b/sphinx/api/decorator.md
@@ -4,7 +4,7 @@
 ```{eval-rst}
 .. currentmodule:: guppylang.decorator
 
-.. decorator:: guppy (*, unitary=False, control=False, dagger=False, power=False, max_qubits=None)
+.. decorator:: guppy (*, unitary=False, control=False, dagger=False, power=False, max_qubits=None, link_name=None)
 
    Registers a function for Guppy compilation. This is the main decorator that applies to most use cases / functions
    written in Guppy. 
@@ -20,6 +20,9 @@
    :keyword max_qubits: Hints the maximum number of qubits that this function uses. When used on the entrypoint function,
      allows to omit the `n_qubits` parameter when calling :func:`~guppylang.defs.GuppyFunctionDefinition.emulator`.
    :type max_qubits: python:int | None
+   :keyword link_name: Override the name the function will receive when compiled into a HUGR package. The default
+     name is based on the fully module-qualified name of the function.
+   :type link_name: python:str | None
    :rtype: GuppyFunctionDefinition
 
    .. code-block:: python


### PR DESCRIPTION
<img width="797" height="551" alt="image" src="https://github.com/user-attachments/assets/7e1832ca-b2de-4548-939f-e21dda0001b3" />

Only updates `@guppy` as the other docs are very sparse, and they should be brought up to date separately. Also does not include any further discussion of why `link_name` is useful, since it will only be really useful once libraries rolls around as a feature, and #103 is merged.

Closes #85