### PR TITLE
docs: add some missing API docs members for 0.21.16

### DIFF
--- a/sphinx/api/decorator.md
+++ b/sphinx/api/decorator.md
@@ -280,6 +280,75 @@
    discard all qubits you know are measured during the circuit, or avoid measurements
    in the circuit and measure in Guppy afterwards.
 
+
+.. py:class:: GuppyKwargs
+   :canonical: guppylang.decorator.GuppyKwargs
+
+   Bases: :class:`typing.TypedDict`
+
+   Typed dictionary specifying the optional keyword arguments for the
+   ``@guppy`` decorator.
+
+   .. py:attribute:: unitary
+      :type: bool
+
+   .. py:attribute:: control
+      :type: bool
+
+   .. py:attribute:: dagger
+      :type: bool
+
+   .. py:attribute:: power
+      :type: bool
+
+   .. py:attribute:: max_qubits
+      :type: int
+
+   .. py:attribute:: link_name
+      :type: str
+
+
+.. py:class:: GuppyStructKwargs
+   :canonical: guppylang.decorator.GuppyStructKwargs
+
+   Bases: :class:`typing.TypedDict`
+
+   Typed dictionary specifying the optional keyword arguments for the
+   ``@guppy.struct`` decorator.
+
+   .. py:attribute:: link_name
+      :type: str
+
+
+.. py:class:: GuppyEnumKwargs
+   :canonical: guppylang.decorator.GuppyEnumKwargs
+
+   Bases: :class:`typing.TypedDict`
+
+   Typed dictionary specifying the optional keyword arguments for the
+   ``@guppy.enum`` decorator.
+
+   .. py:attribute:: link_name
+      :type: str
+
+
+.. py:class:: ParsedGuppyKwargs
+   :canonical: guppylang.decorator.ParsedGuppyKwargs
+
+   Bases: :class:`typing.NamedTuple`
+
+   Parsed representation of the keyword arguments supplied to the
+   ``@guppy`` decorator.
+
+   .. py:attribute:: flags
+      :type: UnitaryFlags
+
+   .. py:attribute:: metadata
+      :type: FunctionMetadata
+
+   .. py:attribute:: link_name
+      :type: str | None
+
 .. autodecorator:: guppylang.decorator.custom_guppy_decorator
 
 .. autofunction:: get_calling_frame

--- a/sphinx/api/defs.md
+++ b/sphinx/api/defs.md
@@ -30,5 +30,11 @@
 
     .. automethod:: __getattr__
 
+
+.. autoclass:: GuppyLibrary
+
+    .. automethod:: compile
+    .. automethod:: check
+
 .. autoexception:: EntrypointArgsError
 ```

--- a/sphinx/api/emulator.md
+++ b/sphinx/api/emulator.md
@@ -18,4 +18,5 @@
     PartialState
     TracedState
     exceptions.EmulatorError
+    exceptions.EmulatorBuildError
 ```


### PR DESCRIPTION
Found some missing classes that are undocumented in 0.21.16 using `just coverage`. Fixing these so the 0.21.x docs are correct.

AI disclosure: used AI to generate the (very manual) docs for the missing classes in `guppylang.decorator` from the 0.21.16 source code.