### PR TITLE
chore: Update supported Python version for Guppy

### DIFF
--- a/sphinx/getting_started.md
+++ b/sphinx/getting_started.md
@@ -26,7 +26,7 @@ Guppy is installed as the [guppylang](https://pypi.org/project/guppylang/) Pytho
       uv add guppylang
 ```
 
-Guppy can be used with Python versions 3.10-14. The macOS, Linux and Windows operating systems are supported.
+Guppy can be used with Python versions 3.12-14. The macOS, Linux and Windows operating systems are supported.
 
 The source code for Guppy can be found in a public repository on [GitHub](https://github.com/quantinuum/guppylang). If you have a feature request or think you have found a bug, feel free to raise a [GitHub issue](https://github.com/quantinuum/guppylang/issues).
 


### PR DESCRIPTION
Guppy V1 is currently slated to drop support for 3.10, 3.11. Updating the Guppy getting started guide to reflect this. This is the only instance of 3.10 or 3.11 in this repo.