### PR TITLE
docs: document generic comptime functions

### DIFF
--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -283,44 +283,23 @@ This kind of dynamic branching is only possible in regular Guppy functions, not 
 
 ### Generalizing comptime functions
 
-Note that Guppy comptime functions cannot yet be used in conjunction with [generic type variables](static.md#generics). Consider the following generic version of the `ladder` comptime function above.
-
-
-```{code-cell} ipython3
----
-tags: [raises-exception]
----
-
-N_QB = guppy.nat_var("n_qb")
-
-@guppy.comptime
-def generic_ladder(qs: array[qubit, N_QB]) -> None:
-    for q1, q2 in zip(qs[1:], qs[:-1]):
-        print("Applying CX")
-        cx(q1, q2)
-    return ladder
-
-generic_ladder.compile_function();  # Compilation fails
-```
-
-There is however a workaround for this particular issue. If we want to generalize this comptime `ladder` function with a variable number of qubits we can do this we can do this with metaprogramming. We can define a Python function which takes an integer argument and returns a instance of the comptime function for that integer.
+With Guppy v1.0 and above, we can use generic variables in the type signatures of generic functions. Let's generalize the `ladder` function defined above to apply a chain of `cx` gates to a qubit array of variable size.
 
 ```{code-cell} ipython3
 from guppylang.defs import GuppyFunctionDefinition
 
-def get_comptime_ladder_function(n_qubits: int) -> GuppyFunctionDefinition:
-    @guppy.comptime
-    def ladder(qs: array[qubit, comptime(n_qubits)]) -> None:
-        for q1, q2 in zip(qs[1:], qs[:-1]):
-            print("Applying CX")
-            cx(q1, q2)
-    return ladder
+k = guppy.nat_var("k")
 
-four_qubit_ladder = get_comptime_ladder_function(n_qubits=4)
-four_qubit_ladder.compile_function();
+@guppy.comptime
+def generic_ladder(qs: array[qubit, k]) -> None:
+    for q1, q2 in zip(qs[1:], qs[:-1]):
+        print("Applying CX")
+        cx(q1, q2)
+
+generic_ladder.check();
 ```
 
-Note how the input to the `ladder` function is of type `array[qubit, comptime(n_qubits)]` so we can create this function for any integer number of qubits.
+Note how the input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
 
 
 ### Arrays and lists

--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -216,7 +216,31 @@ def generic_ladder[k: nat](qs: array[qubit, k]) -> None:
 
 The input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
 
-Note that we cannot compile the `generic_ladder` function directly as the value of `k` is unknown at compile time. However we can call `generic_ladder` inside another function with a concrete `k` value. 
+Note that we cannot compile the `generic_ladder` function directly as the value of `k` is unknown at compile time.
+
+```{code-cell} ipython3
+---
+tags: [raises-exception]
+---
+generic_ladder.compile_function()
+```
+
+ However we can call `generic_ladder` inside another function with a concrete `k` value. 
+
+
+```{code-cell} ipython3
+from guppylang.std.quantum import discard_array
+
+@guppy
+def main() -> None:
+    qs = array(qubit() for _ in range(7))
+    # Invoke generic_ladder on an array of seven qubits (k=7).
+    generic_ladder(qs)
+    discard_array(qs)
+
+main.compile();
+```
+
 
 ### What can and cannot happen at comptime
 

--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -204,6 +204,22 @@ ladder.compile_function();
 As we can see, the ``print`` statement is executed at compile-time.
 We get 9 printed lines, highlighting that the ``for`` loop is compile-time evaluated as well.
 
+With Guppy v1.0 and above, we can use generic variables in the type signatures of generic functions. Let's generalize the `ladder` function defined above to apply a chain of `cx` gates to a qubit array of variable size.
+
+```{code-cell} ipython3
+k = guppy.nat_var("k")
+
+@guppy.comptime
+def generic_ladder(qs: array[qubit, k]) -> None:
+    for q1, q2 in zip(qs[1:], qs[:-1]):
+        print("Applying CX")
+        cx(q1, q2)
+```
+
+Note how the input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
+
+Note that we cannot compile the `generic_ladder` function directly as the value of `k` is unknown at compile time. However we can call `generic_ladder` inside another function with a concrete `k` value. 
+
 ### What can and cannot happen at comptime
 
 Note that not *everything* inside ``comptime`` functions can happen at compile-time.
@@ -281,27 +297,7 @@ dynamic_branch.compile_function();  # Compilation fails
 
 This kind of dynamic branching is only possible in regular Guppy functions, not in a ``comptime`` context.
 
-### Generalizing comptime functions
-
-With Guppy v1.0 and above, we can use generic variables in the type signatures of generic functions. Let's generalize the `ladder` function defined above to apply a chain of `cx` gates to a qubit array of variable size.
-
-```{code-cell} ipython3
-from guppylang.defs import GuppyFunctionDefinition
-
-k = guppy.nat_var("k")
-
-@guppy.comptime
-def generic_ladder(qs: array[qubit, k]) -> None:
-    for q1, q2 in zip(qs[1:], qs[:-1]):
-        print("Applying CX")
-        cx(q1, q2)
-```
-
-Note how the input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
-
-Note that we cannot compile the `generic_ladder` function directly as the value of `k` is unknown at compile time. However we can call `generic_ladder` inside another function with a concrete `k` value.  
-
-
+  
 ### Arrays and lists
 
 Arrays and regular Python lists can be used interchangeably inside ``comptime`` functions since the size of ``comptime`` lists is statically known.

--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -207,10 +207,8 @@ We get 9 printed lines, highlighting that the ``for`` loop is compile-time evalu
 With Guppy v1.0 and above, we can use generic variables in the type signatures of generic functions. Let's generalize the `ladder` function defined above to apply a chain of `cx` gates to a qubit array of variable size.
 
 ```{code-cell} ipython3
-k = guppy.nat_var("k")
-
 @guppy.comptime
-def generic_ladder(qs: array[qubit, k]) -> None:
+def generic_ladder[k: nat](qs: array[qubit, k]) -> None:
     for q1, q2 in zip(qs[1:], qs[:-1]):
         print("Applying CX")
         cx(q1, q2)

--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -216,7 +216,7 @@ def generic_ladder(qs: array[qubit, k]) -> None:
         cx(q1, q2)
 ```
 
-Note how the input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
+The input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
 
 Note that we cannot compile the `generic_ladder` function directly as the value of `k` is unknown at compile time. However we can call `generic_ladder` inside another function with a concrete `k` value. 
 

--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -295,11 +295,11 @@ def generic_ladder(qs: array[qubit, k]) -> None:
     for q1, q2 in zip(qs[1:], qs[:-1]):
         print("Applying CX")
         cx(q1, q2)
-
-generic_ladder.check();
 ```
 
 Note how the input to the `ladder` function is of type `array[qubit, k]` so this comptime function is generic over the number of qubits.
+
+Note that we cannot compile the `generic_ladder` function directly as the value of `k` is unknown at compile time. However we can call `generic_ladder` inside another function with a concrete `k` value.  
 
 
 ### Arrays and lists


### PR DESCRIPTION
closes #94 

This is really quite a powerful feature so I'm sure we can think of some cool algorithms to implement for the notebook examples.

As for the language guide, I've stuck with the basic cx ladder for now. We can remove the pre-V1 workaround where we define a comptime Guppy function inside a Python function and just have a generic type in the function signature.