### PR TITLE
chore: crosslink from the 0.21.x -> 1.0 docs

### DIFF
--- a/sphinx/index.md
+++ b/sphinx/index.md
@@ -8,5 +8,6 @@ api/api_index.md
 guppylang/guppylang/CHANGELOG.md
 migration_guide.md
 faqs.md
+Guppy v1 preview docs <https://docs.quantinuum.com/guppy-v1.x/getting_started.html>
 GitHub <https://github.com/quantinuum/guppylang>
 ```


### PR DESCRIPTION
Crosslinking to the v1 preview docs so people can navigate to the v1 docs from `docs.quantinuum.com/guppy` (currently showing 0.21.16).

<img width="258" height="490" alt="Screenshot 2026-07-16 at 12 26 17" src="https://github.com/user-attachments/assets/1d23d6bb-f3df-4fa8-b85a-4435c9c1bda4" />


I think this is better as an "external link" rather than a crossreference as we have two sphinx sites which we build one at a time. If wer make a crossreference we will get sphinx warnings and the link checker will also complain.


I can also make a PR into `main` linking to the v0.x docs