### PR TITLE
chore: cherry-pick angles section to 0.21.x branch

### DIFF
--- a/sphinx/faqs.md
+++ b/sphinx/faqs.md
@@ -48,6 +48,8 @@ def rotate(q: qubit) -> None:
     rz(q, pi_2)
 ```
 
+See more in the [language guide section on angles](language_guide/data_types/angles.md).
+
 ## Why am I getting "unsupported" errors?
 
 This Guppy function doesn't currently have compilation to HUGR. Please find/raise an issue or find a different way of writing your program.

--- a/sphinx/language_guide/data_types/angles.md
+++ b/sphinx/language_guide/data_types/angles.md
@@ -1,0 +1,29 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Angles
+
+Guppy has a dedicated [`angle`](../../api/generated/guppylang.std.angles.html) type. It allows exact representation of angles for gates in the Clifford hierarchy, which can be useful for optimization.
+
+An angle represents a rotation by a number of half-turns, where a half-turn is equivalent to $\pi$ radians. For example, `angle(1/2)` is equivalent to $\pi/2$. The built-in constant `pi` equals `angle(1)`, so it is useful for converting between angles and radians, as performing arithmetic on it also results in an angle.
+
+```{code-cell} ipython3
+from guppylang import guppy
+from guppylang.std.angles import angle, pi
+from guppylang.std.quantum import qubit, rz
+
+@guppy
+def rotate_twice(q: qubit, r: float) -> None:
+    # Both angle constructions and therefore rotations are equivalent.
+    a = pi * r
+    rz(q, a)
+    a = angle(r)
+    rz(q, a)
+
+rotate_twice.check()
+```
+
+Note that the angle values do not wrap or identify with themselves modulo any number of complete turns, so for example, `angle(2)` does not equal `angle(0)`.

--- a/sphinx/language_guide/data_types/angles.md
+++ b/sphinx/language_guide/data_types/angles.md
@@ -6,7 +6,7 @@ kernelspec:
 
 # Angles
 
-Guppy has a dedicated [`angle`](../../api/generated/guppylang.std.angles.html) type. It allows exact representation of angles for gates in the Clifford hierarchy, which can be useful for optimization.
+Guppy has a dedicated [`angle`](../../api/generated/guppylang.std.angles.rst) type. It allows exact representation of angles for gates in the Clifford hierarchy, which can be useful for optimization.
 
 An angle represents a rotation by a number of half-turns, where a half-turn is equivalent to $\pi$ radians. For example, `angle(1/2)` is equivalent to $\pi/2$. The built-in constant `pi` equals `angle(1)`, so it is useful for converting between angles and radians, as performing arithmetic on it also results in an angle.
 

--- a/sphinx/language_guide/data_types/types_index.md
+++ b/sphinx/language_guide/data_types/types_index.md
@@ -14,4 +14,5 @@ kernelspec:
 arrays.md
 tuples.md
 structs.md
+angles.md
 ```


### PR DESCRIPTION
So that we can deploy this to the 0.21.x version of the docs.

Includes #173 and a minor crossreferencing fix