### PR TITLE
fix: link to landing page from v1 logo

### DIFF
--- a/sphinx/_templates/sidebar/brand.html
+++ b/sphinx/_templates/sidebar/brand.html
@@ -1,0 +1,19 @@
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="https://guppylang.org">
+  {%- block brand_content %}
+  {#- Remember to update the prefetch logic in `block logo_prefetch_links` in base.html #}
+  {%- if logo_url %}
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+  </div>
+  {%- endif %}
+  {%- if theme_light_logo and theme_dark_logo %}
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+  </div>
+  {%- endif %}
+  {% if not theme_sidebar_hide_name %}
+  <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+  {%- endif %}
+  {% endblock brand_content %}
+</a>


### PR DESCRIPTION
This PR just modifies the furo template so that clicking on the Guppy fish logo on https://docs.quantinuum.com/guppy-v1.x/getting_started.html always goes to guppylang.org. Currently this is only the case for the Guppy 0.x docs.

Here is the original furo template 
https://github.com/pradyunsg/furo/blob/522d7e6534706a5acc916dee5ab35a3102e937e8/src/furo/theme/furo/sidebar/brand.html

I have only changed the href. The rest is just copied from the link above.

I tested this by serving the html locally with `just serve` and it works.