### PR TITLE
fix: Revise Guppy libraries documentation for v1 changes

### DIFF
--- a/sphinx/v1_migration.md
+++ b/sphinx/v1_migration.md
@@ -187,17 +187,18 @@ This change also applies to the [state_result](api/generated/guppylang.std.debug
 
 ## Changes to Guppy libraries
 
-Introduced in Guppy v0.21.13, Guppy libraries provide a way to group Guppy functions and structs into a single compilable unit. With the new Guppy v1 release, there are two breakages to Guppy libraries. For up-to-date information on how libraries work in Guppy, refer to the [libraries section](language_guide/libraries.md) of the Guppy language guide.
+Introduced in Guppy v0.21.13, Guppy libraries provide a way to group Guppy functions and structs into a single compilable unit. With the new Guppy v1 release, there are two breakages to the way Guppy libraries are specified. For up-to-date information on how libraries work in Guppy, refer to the [libraries section](language_guide/libraries.md) of the Guppy language guide.
 
 1. Guppy libraries are now created with {py:meth}`guppylang.library.GuppyLibrary.from_members`
 
-In Guppy 0.21, a {py:class}`~guppylang.library.GuppyLibrary` was created using the `guppy.library` API. In Guppy v1, a {py:class}`~guppylang.library.GuppyLibrary` is instead created using the {py:meth}`~guppylang.library.GuppyLibrary.from_members` method.
+In Guppy v0.21.X, a {py:class}`~guppylang.library.GuppyLibrary` was created using `guppy.library(...)`. In Guppy v1, a {py:class}`~guppylang.library.GuppyLibrary` is instead created using the {py:meth}`~guppylang.library.GuppyLibrary.from_members` method.
 
 `````{grid} 2
 
 ````{grid-item-card} Guppy v0.x
 
 ```python
+from guppylang import guppy
 # Create a GuppyLibrary from
 # three function definitions
 lib = guppy.library(
@@ -210,7 +211,7 @@ lib = guppy.library(
 
 ````{grid-item-card} Guppy v1.0
 ```python
-
+from guppylang.library import GuppyLibrary
 # Create a GuppyLibrary from
 # three function definitions
 lib = GuppyLibrary.from_members(
@@ -221,11 +222,11 @@ lib = GuppyLibrary.from_members(
 ```
 `````
 
-This change means that the entire API for Guppy libraries is self-contained within the {py:mod}`guppylang.library` module. 
+Now, the entire API for Guppy libraries is contained within the new {py:mod}`guppylang.library` module, easing addition of new features with more intricate interactions with the rest of the compiler. 
 
 2. `link_name` is now its own decorator
 
-Guppy libraries can also be used to link function declarations against function calls, by associating a `link_name` with a function definition. In Guppy 0.21, this was accomplished by specifying `link_name` as a keyword argument in the `@guppy` decorator. In Guppy v1, {py:func}`~guppylang.library.link_name` is its own decorator. 
+Guppy libraries can also be used to provide function definitions for function declarations, by fixing their `link_name` with a function definition. In Guppy v0.21.X, this was accomplished by specifying the keyword argument in `@guppy(link_name=...)`. In Guppy v1, {py:func}`~guppylang.library.link_name` is its own decorator. 
 This was changed to keep the keyword arguments to `@guppy` related to compilation and to provide better error messages to the user.
 
 
@@ -235,6 +236,8 @@ This was changed to keep the keyword arguments to `@guppy` related to compilatio
 ````{grid-item-card} Guppy v0.x
 
 ```python
+from guppylang import guppy
+
 @guppy(link_name="my.lib.func")
 def my_func() -> None:
     pass
@@ -243,6 +246,9 @@ def my_func() -> None:
 
 ````{grid-item-card} Guppy v1.0
 ```python
+from guppylang import guppy
+from guppylang.library import link_name
+
 @guppy
 @link_name("my.lib.func")
 def my_func() -> None:


### PR DESCRIPTION
Updated documentation for Guppy libraries in v1, clarifying changes in library creation and the use of link_name as a decorator.