### PR TITLE
docs: reorder API docs sections

### DIFF
--- a/sphinx/api/api_index.md
+++ b/sphinx/api/api_index.md
@@ -4,9 +4,9 @@
 :maxdepth: 1
 
 decorator.md
-emulator.md
-defs.md
 std.md
+defs.md
+emulator.md
 experimental.md
 ```
 

--- a/sphinx/language_guide/language_guide_index.md
+++ b/sphinx/language_guide/language_guide_index.md
@@ -13,7 +13,7 @@ If you're brand new to Guppy, check out our [getting started guide](../getting_s
 
 
 ```{toctree}
-:maxdepth: 1
+:maxdepth: 2
 
 data_types/types_index.md
 functions.md


### PR DESCRIPTION
Doing #191 but effectively backporting the change to 0.21.x