### PR TITLE
docs: Clean Langauge Guide index page

### DIFF
--- a/sphinx/language_guide/language_guide_index.md
+++ b/sphinx/language_guide/language_guide_index.md
@@ -6,12 +6,13 @@ kernelspec:
 
 # Guppy Language Guide
 
-Welcome to the Guppy Language Guide. This guide is intended to provide a step by step walkthrough of the major features of the Guppy programming language. 
-The guide contains explanations of the key Guppy data types, the ownership model, control flow and more. The content will be expanded and improved as more features become available.
+This guide is intended to provide a step by step walkthrough of the major features of the Guppy programming language. 
+It contains explanations of the key Guppy data types, functions and control flow, as well as the ownership model and static compilation.
 
-If you're brand new to Guppy, check out our [getting started guide](../getting_started.md) to install Guppy and start writing your first programs. There is also a [gallery of example programs](../examples_index.md) showcasing various quantum algorithms implemented in Guppy.
+If you are new to Guppy then first check out our [getting started guide](../getting_started.md) to install Guppy and start writing your first programs.
 
 
+---
 ```{toctree}
 :maxdepth: 2
 
@@ -26,3 +27,6 @@ comptime.md
 libraries.md
 random.md
 ```
+---
+
+See also the [gallery of example programs](../examples_index.md) showcasing various quantum algorithms implemented in Guppy. This allows one to see the above language features within a general context. 


### PR DESCRIPTION
This is just a simple tidy up of the start of the guide, removing repetition and improving things visually.