### PR TITLE
feat: Document metadata decorators

### DIFF
--- a/sphinx/api/decorator.md
+++ b/sphinx/api/decorator.md
@@ -304,6 +304,10 @@
 
 .. autodecorator:: guppylang.decorator.custom_guppy_decorator
 
+.. autodecorator:: metadata
+
+   See :doc:`../language_guide/custom_metadata`.
+
 .. autodecorator:: expected_qubits
 
 .. autofunction:: get_calling_frame

--- a/sphinx/language_guide/custom_metadata.md
+++ b/sphinx/language_guide/custom_metadata.md
@@ -6,7 +6,9 @@ kernelspec:
 
 # Custom Metadata
 
-Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). This can be done with the {py:deco}`guppylang.decorator.metadata` decorator, which you can add below the {py:deco}`guppylang.decorator.guppy` decorator:
+Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). Attaching metadata can, for example, be helpful in scenarios where one wants to mark symbols that can later be clearly identified in the compilation product, be it for debugging purposes or further special handling. It can also help with providing hints or even required annotations to later stages that take HUGRs as inputs (such as optimisation passes or compilers), provided they are aware of the metadata keys in use.
+
+Custom metadata can be added with the {py:deco}`guppylang.decorator.metadata` decorator, which you can add below the {py:deco}`guppylang.decorator.guppy` decorator:
 
 ```{code-cell} ipython3
 from hugr.ops import FuncDefn

--- a/sphinx/language_guide/custom_metadata.md
+++ b/sphinx/language_guide/custom_metadata.md
@@ -6,7 +6,7 @@ kernelspec:
 
 # Custom Metadata
 
-Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). You can do this via the {py:func}`~guppylang.decorator.metadata` decorator, which you can add below the {py:func}`~guppylang.decorator.guppy` decorator:
+Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). You can do this via the {py:deco}`guppylang.decorator.metadata` decorator, which you can add below the {py:deco}`guppylang.decorator.guppy` decorator:
 
 ```{code-cell} ipython3
 from hugr.ops import FuncDefn
@@ -26,7 +26,7 @@ assert funcs[0].metadata["my-key"] == {"arbitrary": ["value"]}
 ```
 Note that only functions currently compile to objects that can have metadata attached. Types on the other hand, like structs and enums, do not.
 
-If you have keys that you use often, you may want to create your own decorator simply by wrapping {py:func}`~guppylang.decorator.metadata`:
+If you have keys that you use often, you may want to create your own decorator simply by wrapping {py:deco}`guppylang.decorator.metadata`:
 ```{code-cell} ipython3
 from hugr.ops import FuncDefn
 from guppylang import guppy
@@ -48,6 +48,6 @@ assert funcs[0].metadata["my-wonderful-key"] == "a-wonderful-value"
 ```
 
 The Guppy compiler contains some examples of this wrapper mechanism, including ones where the metadata is used in the Guppy compiler itself, like:
-- The {py:func}`~guppylang.library.link_name` decorator, see [](libraries.md#linking-and-visibility).
-- The {py:func}`~guppylang.decorator.expected_qubits` decorator, see [](../api/emulator.md).
+- The {py:deco}`guppylang.library.link_name` decorator, see [](libraries.md#linking-and-visibility).
+- The {py:deco}`guppylang.decorator.expected_qubits` decorator, see [](../api/emulator.md).
 

--- a/sphinx/language_guide/custom_metadata.md
+++ b/sphinx/language_guide/custom_metadata.md
@@ -6,7 +6,7 @@ kernelspec:
 
 # Custom Metadata
 
-Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). You can do this via the {py:deco}`guppylang.decorator.metadata` decorator, which you can add below the {py:deco}`guppylang.decorator.guppy` decorator:
+Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). This can be done with the {py:deco}`guppylang.decorator.metadata` decorator, which you can add below the {py:deco}`guppylang.decorator.guppy` decorator:
 
 ```{code-cell} ipython3
 from hugr.ops import FuncDefn

--- a/sphinx/language_guide/custom_metadata.md
+++ b/sphinx/language_guide/custom_metadata.md
@@ -1,0 +1,53 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Custom Metadata
+
+Guppy supports adding arbitrary metadata to symbols that will be lowered to the final compilation product (the HUGR package). You can do this via the {py:func}`~guppylang.decorator.metadata` decorator, which you can add below the {py:func}`~guppylang.decorator.guppy` decorator:
+
+```{code-cell} ipython3
+from hugr.ops import FuncDefn
+from guppylang import guppy
+from guppylang.decorator import metadata
+
+@guppy
+@metadata("my-key", {"arbitrary": ["value"]})
+def my_func() -> None:
+    pass
+
+package = my_func.compile()
+
+funcs = [v for v in package.modules[0].values() if isinstance(v.op, FuncDefn)]
+assert len(funcs) == 1
+assert funcs[0].metadata["my-key"] == {"arbitrary": ["value"]}
+```
+Note that only functions currently compile to objects that can have metadata attached. Types on the other hand, like structs and enums, do not.
+
+If you have keys that you use often, you may want to create your own decorator simply by wrapping {py:func}`~guppylang.decorator.metadata`:
+```{code-cell} ipython3
+from hugr.ops import FuncDefn
+from guppylang import guppy
+from guppylang.decorator import metadata
+
+def my_wonderful_metadata(value: str):
+    return metadata("my-wonderful-key", value)
+
+@guppy
+@my_wonderful_metadata("a-wonderful-value")
+def my_func() -> None:
+    pass
+
+package = my_func.compile()
+
+funcs = [v for v in package.modules[0].values() if isinstance(v.op, FuncDefn)]
+assert len(funcs) == 1
+assert funcs[0].metadata["my-wonderful-key"] == "a-wonderful-value"
+```
+
+The Guppy compiler contains some examples of this wrapper mechanism, including ones where the metadata is used in the Guppy compiler itself, like:
+- The {py:func}`~guppylang.library.link_name` decorator, see [](libraries.md#linking-and-visibility).
+- The {py:func}`~guppylang.decorator.expected_qubits` decorator, see [](../api/emulator.md).
+

--- a/sphinx/language_guide/language_guide_index.md
+++ b/sphinx/language_guide/language_guide_index.md
@@ -24,5 +24,6 @@ ownership.md
 measurement.md
 comptime.md
 libraries.md
+custom_metadata.md
 random.md
 ```

--- a/sphinx/language_guide/libraries.md
+++ b/sphinx/language_guide/libraries.md
@@ -119,6 +119,7 @@ def main() -> None:
 main.emulator(n_qubits=1, libs=[lib_pkg]).run()
 ```
 
+(linking-and-visibility)=
 ## Linking and visibility
 
 As of the HUGR Python package `hugr>=0.16.0`, it is possible to *link* packages, replacing calls to function declarations with calls to the corresponding function definitions, if they are available:

--- a/sphinx/language_guide/libraries.md
+++ b/sphinx/language_guide/libraries.md
@@ -151,7 +151,7 @@ For the introductory example, assuming the functions reside in a file at `src/my
 - ``mylib.foo.bar.a_third_func``
 
 To be able to link the corresponding declarations and the functions together, they need to have the same name inside the HUGR package.
-In cases where the default name for declarations is wrong (e.g. when they are declared in some other module than the definitions or have different function names), the name they will receive can be manually overridden using the ``link_name`` decorator:
+In cases where the default name for declarations is wrong (e.g. when they are declared in some other module than the definitions or have different function names), the name they will receive can be manually overridden using the ``@link_name`` decorator:
 ```{code-cell} ipython3
 from guppylang import guppy
 from guppylang.library import link_name
@@ -198,7 +198,7 @@ class MyStruct:
     @guppy.declare
     def my_method(self) -> None: ...
 ```
-Specifying ``link_name`` on these methods will work as with top-level functions, with the default value including the struct name as part of the method name.
+Specifying ``@link_name`` on these methods will work as with top-level functions, with the default value including the struct name as part of the method name.
 However, the ``@guppy.struct`` and ``@guppy.enum`` decorators also support changing the name prefix up to and including the type name for all members using the default mechanism:
 ```{code-cell} ipython3
 from guppylang import guppy


### PR DESCRIPTION
Documents the metadata and related decorators, and fixes a few typos:
<img width="808" height="99" alt="image" src="https://github.com/user-attachments/assets/71fcc04c-e664-4d36-877d-c411670a6540" />
<img width="510" height="732" alt="image" src="https://github.com/user-attachments/assets/ebde6070-37d6-4842-9cfa-a5adbbc05a52" />

Closes #159