### PR TITLE
feat: Cleanup optimizer API structure

### DIFF
--- a/sphinx/api/optimizer.md
+++ b/sphinx/api/optimizer.md
@@ -1,16 +1,14 @@
 # Optimizer
 
 ```{eval-rst}
+
 .. currentmodule:: guppylang.optimizer
+.. automodule:: guppylang.optimizer
+.. autosummary::
+    :template: autosummary/class.rst
+    :toctree: generated
+    :nosignatures:
 
-.. autoclass:: OptimizationLevel
-    :members:
-
-.. autoclass:: OptimizerInstance
-
-    .. automethod:: with_optimization
-    .. automethod:: emulator
-    .. automethod:: compile
-    .. automethod:: compile_entrypoint
-    .. automethod:: compile_function
+    OptimizerInstance
+    OptimizationLevel
 ```

--- a/sphinx/language_guide/static.md
+++ b/sphinx/language_guide/static.md
@@ -12,6 +12,8 @@ kernelspec:
 While Guppy functions mostly look like regular Python functions (just annotated with the `@guppy` decorator), the code they contain is processed differently compared to Python code. You can normally run Python programs directly on your machine, whereas we want to be able to run Guppy programs with a variety of simulators and quantum hardware. 
 
 In order to achieve this, programs are statically compiled into an intermediate representation called [HUGR](https://github.com/quantinuum/hugr?tab=readme-ov-file).  An intermediate representation allows us to optimise programs before further converting them to code that can actually be executed on the desired target. 
+The optimisations applied during compilation can be configured using
+[optimization levels](../api/optimizer.md).
 
 A big advantage of compilation is that it helps us catch errors earlier than runtime. For example, the compiler ensures that variables are definitely defined before they are used.
 

--- a/sphinx/language_guide/static.md
+++ b/sphinx/language_guide/static.md
@@ -12,7 +12,7 @@ kernelspec:
 While Guppy functions mostly look like regular Python functions (just annotated with the `@guppy` decorator), the code they contain is processed differently compared to Python code. You can normally run Python programs directly on your machine, whereas we want to be able to run Guppy programs with a variety of simulators and quantum hardware. 
 
 In order to achieve this, programs are statically compiled into an intermediate representation called [HUGR](https://github.com/quantinuum/hugr?tab=readme-ov-file).  An intermediate representation allows us to optimise programs before further converting them to code that can actually be executed on the desired target. 
-The optimisations applied during compilation can be configured using
+The optimizations applied during compilation can be configured using
 [optimization levels](../api/optimizer.md).
 
 A big advantage of compilation is that it helps us catch errors earlier than runtime. For example, the compiler ensures that variables are definitely defined before they are used.


### PR DESCRIPTION
Copies the structure of the [emulator API docs](https://docs.quantinuum.com/guppy/api/emulator.html) for the optimization API.

This PR paired with https://github.com/Quantinuum/guppylang/pull/2121 closes https://github.com/Quantinuum/guppy-docs/issues/154.

<img width="2388" height="3746" alt="image" src="https://github.com/user-attachments/assets/fa1374e2-dc20-4833-8e67-0b25de82a04b" />