### PR TITLE
fix: correct section headings in type args chapter

### DIFF
--- a/sphinx/language_guide/type_arg_syntax.md
+++ b/sphinx/language_guide/type_arg_syntax.md
@@ -28,9 +28,11 @@ foo[int, str](42, "guppy")
 
 Usually these type arguments can be left to be inferred by the type checker.
 
-### Bounds
+## Bounds
+
 Generic functions can have their type bounds specified by an annotation in the type parameter list. In Guppy these bounds can mean three things:
-#### Linearity
+
+### Linearity
 The type argument can be required to be copyable and/or droppable using the `Copy`, `Drop` bounds:
 
 ```{code-cell} ipython3
@@ -42,7 +44,7 @@ def copy[T: (Copy, Drop)](t: T) -> tuple[T, T]:
     return t, t
 ```
 
-#### Const arguments
+### Const arguments
 By default, a type parameter specified in this way represents an arbitrary type. We can also add annotations to the parameters.
 
 These annotations can also be used to specify that the parameter is a _const nat_ parameter, rather than a type:
@@ -55,7 +57,7 @@ def replicate[T: (Copy, Drop), N: nat](elem: T) -> array[T, N]:
     return array(elem for _ in range(N))
 ```
 
-#### Protocol bounds
+### Protocol bounds
  Type parameter syntax is used to specify the _protocols_ that a type argument must implement. In the below example, any type argument `T` to the function `foo` must implement the `MyProto` protocols.
 
 Assuming we've defined a protocol, `MyProto`:
@@ -66,7 +68,7 @@ class MyProto[T]:
     def foo[T](self, t: T) -> None: ...
 ```
 
-we can require that it is implemented by a type arg `T` by writing:
+We can require that it is implemented by a type arg `T` by writing:
 
 ```{code-cell} ipython3
  @guppy
@@ -75,7 +77,7 @@ we can require that it is implemented by a type arg `T` by writing:
 
  ```
 
-### Type Arguments to Classes
+## Type Arguments to Classes
 Guppy structs and protocols can also take type parameters in the same way. The type parameters will be in scope for the signatures of the methods:
 
 ```{code-cell} ipython3

--- a/sphinx/language_guide/type_arg_syntax.md
+++ b/sphinx/language_guide/type_arg_syntax.md
@@ -96,7 +96,7 @@ def myfoo() -> None:
     return baz(MyStruct[int]())
 ```
 
-### Type aliases
+## Type aliases
 Type variables for Guppy type aliases must still be declared in the python 3.10 style:
 
 ```{code-cell} ipython3
@@ -111,5 +111,5 @@ N = guppy.nat_var("N")
 QArr = guppy.type_alias("QArr", "array[qubit, N]", params=[N])
 ```
 
-### Caveats
+## Caveats
 * Note that Guppy type parameters stand in for one type or constant. Python's `TypeVarTuple` and `ParamSpec` parameters (written as `*T` and `**P`, respectively) aren't supported.


### PR DESCRIPTION
Fixes some warnings like this.

Basically all of the markdown headings need to be consecutive. Just need to make sure I've grouped the subsections as intended.

```
guppy-docs/sphinx/language_guide/type_arg_syntax.md.rst:31: WARNING: Non-consecutive header level increase; H1 to H3 [myst.header]
guppy-docs/sphinx/language_guide/type_arg_syntax.md.rst:78: WARNING: Non-consecutive header level increase; H1 to H3 [myst.header]
guppy-docs/sphinx/language_guide/type_arg_syntax.md.rst:97: WARNING: Non-consecutive header level increase; H1 to H3 [myst.header]
guppy-docs/sphinx/language_guide/type_arg_syntax.md.rst:112: WARNING: Non-consecutive header level increase; H1 to H3 [myst.header]
```

towards #208 