### PR TITLE
fix: Fix some minor mistakes

### DIFF
--- a/sphinx/language_guide/comptime.md
+++ b/sphinx/language_guide/comptime.md
@@ -154,7 +154,7 @@ plus_state.compile_function();
 
 ## Compile time arguments
 
-Guppy also supports "comptime arguments". This function arguments can be annotated as known at compile time. This allows us to write Guppy functions and methods which are more expressive provided we do not use any runtime values.
+Guppy also supports "comptime arguments". These function arguments can be annotated as known at compile time. This allows us to write Guppy functions and methods which are more expressive provided we do not use any runtime values.
 
 As an example, let us consider a function which allocates an array of `n` qubits using a comprehension. 
 ```{code-cell} ipython3

--- a/sphinx/language_guide/data_types/structs.md
+++ b/sphinx/language_guide/data_types/structs.md
@@ -14,7 +14,7 @@ In Guppy, structures (abbreviated as structs) provide a way for users to group r
  But the data in a struct instance is accessed via the fields instead of tuple unpacking or indexing. Note that as of Guppy v1, structs are affine and mutable by default. Prior to the v1 release, Guppy structs were always immutable.
  We can also define methods on structs, just as we can on Python classes.
 
-To define a Guppy struct we use the python `class` keyword together with the `@guppy.struct` decorator.
+To define a Guppy struct we use the Python `class` keyword together with the `@guppy.struct` decorator.
 
 To illustrate how structs work in Guppy, let's define a `PauliString` struct that represents a tensor product of single-qubit Pauli operators. 
 

--- a/sphinx/language_guide/ownership.md
+++ b/sphinx/language_guide/ownership.md
@@ -211,7 +211,7 @@ borrow_consumed.check() # Check fails :(
 We have just seen how Guppy does not allow consumed qubits to be used. Conversely, there is also a safety concern if qubits are not deallocated after they are used. Unmeasured temporary qubits often indicate an implementation bug. Further, if these qubits are discarded this frees up qubits which can potentially be used later in the computation.
 
 Guppy ensures that qubits are properly deallocated after they are no longer in use. 
-To enable this safety guarantee, guppy functions must either consume a qubit they own (by a destructive measurement or discard) or return it to the calling scope.
+To enable this safety guarantee, Guppy functions must either consume a qubit they own (by a destructive measurement or discard) or return it to the calling scope.
 
 Here the function below allocates a qubit and applies a Hadamard gate without returning the qubit. The Hadamard merely borrows the qubit without consuming it. This is considered a leakage error as there would be no remaining reference to the qubit `q` once `main` returns.
 

--- a/sphinx/language_guide/protocols.md
+++ b/sphinx/language_guide/protocols.md
@@ -35,7 +35,7 @@ class MyProto[T]:
 ```
 
 ```{note}
-The bodies of the methods declared with `@guppy.require` must be empty (literally `...`). Default implementations of protocol methods is not currently supported in Guppy.
+The bodies of the methods declared with `@guppy.require` must be empty (literally `...`). Default implementations of protocol methods are not currently supported in Guppy.
 ```
 
 ### Implementing a protocol
@@ -180,9 +180,9 @@ run_experiment.check()
 ```
 
 ## Callable
-As of Guppy v1.0, the [`Callable`](functions.md#guppy-functions-can-be-higher-order-functions) type in guppy is treated as an interface.
+As of Guppy v1.0, the [`Callable`](functions.md#guppy-functions-can-be-higher-order-functions) type in Guppy is treated as an interface.
 This means that taking a `Callable` argument in a function will have that function require a type parameter that implements the `Callable` protocol.
 
-This protocol behaves differently to user-defined protocols because it's not currently possible in guppy to correctly write the type signature of `__call__`.
+This protocol behaves differently to user-defined protocols because it's not currently possible in Guppy to correctly write the type signature of `__call__`.
 
-Thus, there are special cases for [guppy functions](../api/generated/guppylang.std.builtins.Function.rst) (e.g. which have type `Function[[A,B],C]`), and [modified](modifiers/modifiers_index.md) versions of those functions.
+Thus, there are special cases for [Guppy functions](../api/generated/guppylang.std.builtins.Function.rst) (e.g. which have type `Function[[A,B],C]`), and [modified](modifiers/modifiers_index.md) versions of those functions.


### PR DESCRIPTION
Mostly capitalisation of Guppy in prose