### PR TITLE
docs: reorganize language guide index

### DIFF
--- a/sphinx/language_guide/language_guide_index.md
+++ b/sphinx/language_guide/language_guide_index.md
@@ -18,18 +18,18 @@ If you are new to Guppy then first check out our [getting started guide](../gett
 
 data_types/types_index.md
 functions.md
-type_arg_syntax.md
 control_flow.md
 static.md
-python_differences.md
 ownership.md
 measurement.md
 comptime.md
-libraries.md
-custom_metadata.md
-protocols.md
-random.md
 modifiers/modifiers_index.md
+protocols.md
+libraries.md
+python_differences.md
+random.md
+type_arg_syntax.md
+custom_metadata.md
 ```
 ---
 


### PR DESCRIPTION
Reorganising this for clarity. In particular modifiers were too far down and things like type args were too close to the top.